### PR TITLE
fix initialization

### DIFF
--- a/client/fidelity/subject-matter-expert-review/controllers/subjectMatterExpertReviewController.ts
+++ b/client/fidelity/subject-matter-expert-review/controllers/subjectMatterExpertReviewController.ts
@@ -80,7 +80,9 @@ export function subjectMatterExpertReviewCtrl(
         delete authoringWorkspace.authoringTopBarButtonsToHide['article-edit--topbar--sendto-publish'];
     }
 
-    function onInitialize() {
+    $scope.onInit = function() {
+        // called from the view
+
         const queryParams = $location.search();
 
         if (queryParams['item'] != null && queryParams['action'] === 'edit') {
@@ -115,8 +117,6 @@ export function subjectMatterExpertReviewCtrl(
             superdeskFlags.flags.workqueue = previousWorkspaceFlagValue;
         });
     }
-    
-    onInitialize();
     
     $scope.$on('$destroy', onDestroy);
 

--- a/client/fidelity/subject-matter-expert-review/views/subject-matter-expert-review.html
+++ b/client/fidelity/subject-matter-expert-review/views/subject-matter-expert-review.html
@@ -1,4 +1,5 @@
 <div
+    ng-init="onInit()"
     sd-monitoring-view data-type="'custom-monitoring-view'"
     custom-data-source="customDataSource"
     on-monitoring-item-select="onMonitoringItemSelect"


### PR DESCRIPTION
SDFID-530

Angularjs `$scope` supports [`$destroy` event](https://docs.angularjs.org/api/ng/type/$rootScope.Scope#events), but no event is available for initialization. I was running initialization code inline in the controller which worked most of the time, but if the controller was being destroyed and initialized frequently, [a race condition happened](https://user-images.githubusercontent.com/2076953/52419219-f657a480-2aef-11e9-8e25-940d6795a3a1.gif).

I fixed it by adding `ng-init` directive in the view and used that for initialization code.