### PR TITLE
change(login): Change 'single sign on' to 'sign in'

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -87,6 +87,7 @@ LANGUAGES = [
 ]
 
 SAML_PATH = env('SAML_PATH', os.path.join(ABS_PATH, 'saml'))
+SAML_LABEL = env('SAML_LABEL', 'Sign In')
 
 SCHEMA = {
     'composite': {


### PR DESCRIPTION
The label is fetched from the server so I overrode the default which is declared [here](https://github.com/superdesk/superdesk-core/blob/b53aed1c2c16230847b72aacff34557607eec139/superdesk/default_settings.py#L660) if no env is found