### PR TITLE
[COMPLIANCE]use new content editor to prepend the embed

### DIFF
--- a/server/fidelity/tests/compliance_test.py
+++ b/server/fidelity/tests/compliance_test.py
@@ -8,6 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from html import escape
 from datetime import date, datetime
 from superdesk.tests import TestCase
 from superdesk import get_resource_service
@@ -37,7 +38,8 @@ class ComplianceCorrectionTestCase(TestCase):
         item = archive_service.find_one(None, _id='123')
         self.assertTrue(item['body_text'].startswith(DEFAULT_EOL_TEXT))
         self.assertTrue(item['body_html'].startswith(
-            '<p class="compliance-notice">{DEFAULT_EOL_TEXT}</p>'.format(DEFAULT_EOL_TEXT=DEFAULT_EOL_TEXT)))
+            '<div class="embed-block"><p class="compliance-notice">{DEFAULT_EOL_TEXT}</p></div>'.format(
+                DEFAULT_EOL_TEXT=escape(DEFAULT_EOL_TEXT))))
         archive_versions_service = get_resource_service('archive_versions')
         version_item = archive_versions_service.find_one(None, guid='123', _current_version=2)
         self.assertIsNotNone(version_item)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -5,4 +5,4 @@ python3-saml==1.2.6
 lxml==3.8.0
 feedgen==0.9.0
 
--e git+git://github.com/superdesk/superdesk-core.git@develop#egg=Superdesk-Core
+-e git+git://github.com/superdesk/superdesk-core.git@master#egg=Superdesk-Core


### PR DESCRIPTION
The new content editor is used to prepend end of life notice as an
embed, this way it will be visible and editable in the client.

SDESK-4799