### PR TITLE
[ARCHIVE] generate Fidelity internal id on item creation

### DIFF
--- a/server/features/fidelity_archive.feature
+++ b/server/features/fidelity_archive.feature
@@ -1,0 +1,43 @@
+Feature: Fidelity Specific Archive Behaviour
+
+    @auth
+    Scenario: Create new text item and get internal id
+        Given empty "archive"
+        Given "content_types"
+        """
+        [{"_id": "test_profile", "schema": {
+            "headline": {"default": "default_headline"},
+            "internal_id" : {
+                    "type" : "text",
+                    "required" : false,
+                    "enabled" : true,
+                    "nullable" : true
+            },
+            "disclaimer" : {
+                    "type" : "text",
+                    "required" : false,
+                    "enabled" : true,
+                    "nullable" : true
+            }
+        }}]
+        """
+        When we post to "/archive"
+        """
+        [{"type": "text", "profile": "test_profile", "body_html": "<p>content</p>"}]
+        """
+        Then we get new resource
+        """
+        {
+        	"_id": "__any_value__",
+            "guid": "__any_value__",
+            "type": "text",
+            "extra": {
+                "internal_id": "__any_value__",
+                "disclaimer": "__any_value__"
+            },
+            "original_creator": "__any_value__",
+            "word_count": 1,
+            "operation": "create",
+            "sign_off": "abc"
+        }
+        """

--- a/server/fidelity/identifier_generator.py
+++ b/server/fidelity/identifier_generator.py
@@ -1,0 +1,42 @@
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import logging
+import pytz
+from datetime import datetime
+from superdesk import app, get_resource_service
+from superdesk.signals import item_create
+
+logger = logging.getLogger(__name__)
+
+
+def generate_id(sender, item, **kwargs):
+    content_types_service = get_resource_service('content_types')
+    profile = content_types_service.find_one(None, _id=item['profile'])
+    set_field_id = app.config['INTERNAL_ID_SET_CUSTOM_FIELD_ID']
+    if set_field_id not in profile['schema']:
+        return
+    extra = item.setdefault('extra', {})
+    tz = pytz.timezone(app.config['DEFAULT_TIMEZONE'])
+    now = datetime.now(tz=tz)
+    template = app.config['INTERNAL_ID_TPL']
+    sequences_service = get_resource_service('sequences')
+    sequence_key = 'fidelity_internal_id_{year}'.format(year=now.year)
+    sequence_number = sequences_service.get_next_sequence_number(sequence_key)
+    internal_id = template.format(
+        year_short=str(now.year)[-2:],
+        year_sequence=sequence_number,
+    )
+    extra[set_field_id] = internal_id
+    for field_id in app.config['INTERNAL_ID_APPEND_CUSTOM_FIELDS_IDS']:
+        if field_id in profile['schema']:
+            extra[field_id] = extra.setdefault(field_id, '') + '<br>' + internal_id
+
+
+def init_app(app):
+    item_create.connect(generate_id)

--- a/server/fidelity/tests/internal_id_test.py
+++ b/server/fidelity/tests/internal_id_test.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from datetime import datetime
+import pytz
+from superdesk.tests import TestCase
+from superdesk import get_resource_service
+
+TEST_TPL = "ED{year_short} - {year_sequence:04}"
+
+
+class InternalIdTestCase(TestCase):
+
+    def setUp(self):
+        self.app.config.update({
+            "INTERNAL_ID_TPL": TEST_TPL,
+            "INTERNAL_ID_SET_CUSTOM_FIELD_ID": "internal_id",
+            "INTERNAL_ID_APPEND_CUSTOM_FIELDS_IDS": ['disclaimer'],
+        })
+
+    def test_internal_id_on_new_item(self):
+        """Check that an internal ID corresponding to template is built on item creation"""
+        tz = pytz.timezone(self.app.config['DEFAULT_TIMEZONE'])
+        now = datetime.now(tz=tz)
+        self.app.data.insert(
+            "content_types",
+            [
+                {
+                    "_id": "test_profile",
+                    "schema": {
+                        "headline": {"default": "default_headline"},
+                        "internal_id": {"type": "text", "required": False, "enabled": True, "nullable": True},
+                        "disclaimer": {"type": "text", "required": False, "enabled": True, "nullable": True},
+                    },
+                }
+            ],
+        )
+        archive_service = get_resource_service('archive')
+        item_id = archive_service.post([{
+            "type": "text",
+            "profile": "test_profile",
+            "body_html": "<p>content</p>",
+            "extra": {"disclaimer": "some disclaimer"},
+        }])[0]
+        new_item = archive_service.find_one(None, _id=item_id)
+        expected_tpl = TEST_TPL.format(
+            year_short=str(now.year)[-2:],
+            year_sequence=1,
+        )
+        self.assertEqual(
+            new_item['extra']['internal_id'],
+            expected_tpl
+        )
+        self.assertEqual(
+            new_item['extra']['disclaimer'],
+            "some disclaimer<br>{}".format(expected_tpl)
+        )
+
+    def test_internal_id_not_set(self):
+        """Check that an internal ID is not added if it is not present in profile's schema"""
+        self.app.config.update({
+            "INTERNAL_ID_TPL": TEST_TPL,
+            "INTERNAL_ID_SET_CUSTOM_FIELD_ID": "internal_id",
+            "INTERNAL_ID_APPEND_CUSTOM_FIELDS_IDS": ['disclaimer'],
+        })
+        self.app.data.insert(
+            "content_types",
+            [
+                {
+                    "_id": "test_profile",
+                    "schema": {
+                        "headline": {"default": "default_headline"},
+                    },
+                }
+            ],
+        )
+        archive_service = get_resource_service('archive')
+        item_id = archive_service.post([{
+            "type": "text",
+            "profile": "test_profile",
+            "body_html": "<p>content</p>",
+        }])[0]
+        new_item = archive_service.find_one(None, _id=item_id)
+        self.assertNotIn('internal_id', new_item.get('extra', {}))

--- a/server/settings.py
+++ b/server/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS.extend([
     'superdesk.auth.saml',
     'fidelity',
     'fidelity.compliance',
+    'fidelity.identifier_generator',
 ])
 
 RENDITIONS = {
@@ -120,3 +121,17 @@ OVERRIDE_EDNOTE_FOR_CORRECTIONS = False
 CONTENTAPI_INSTALLED_APPS += (
     'fidelity.content_api_rss',
 )
+
+# Fidelity Internal ID
+
+# keys used in template:
+# year_short: last 2 digits of year
+# year_sequence: incremental id, reset every year
+INTERNAL_ID_TPL = "ED{year_short} - {year_sequence:04}"
+
+# internal id will be set in following field, if it exists in content profile
+INTERNAL_ID_SET_CUSTOM_FIELD_ID = "internal_id"
+
+# internal id will be appended to following fields (after a line feed),
+# if they exist in content profile
+INTERNAL_ID_APPEND_CUSTOM_FIELDS_IDS = ['disclaimer']


### PR DESCRIPTION
If template used for an item creation contains the `internal_id` custom
text field, it will be filled according to settings (see settings
comments for explanation).

`internal_id` can also be appended to field specified in
`INTERNAL_ID_APPEND_CUSTOM_FIELDS_IDS` setting (default to `disclaimer`
field).

SDFID-590