### PR TITLE
[COMPLIANCE] fixed inserting new version after item correction

### DIFF
--- a/server/fidelity/compliance.py
+++ b/server/fidelity/compliance.py
@@ -15,6 +15,7 @@ from flask import current_app as app
 from eve.utils import config
 import superdesk
 from superdesk.celery_app import celery
+from apps.archive.common import insert_into_versions
 
 logger = logging.getLogger(__name__)
 DEFAULT_EOL_TEXT = "This content is no longer updated by Fidelity International"
@@ -64,6 +65,13 @@ class ComplianceEOLCheck(superdesk.Command):
                     "be corrected: {e}".format(item_id=item_id, e=e))
                 nb_failed += 1
                 continue
+            else:
+                try:
+                    insert_into_versions(item_id)
+                except Exception as e:
+                    logger.error(
+                        "the item {item_id} could not be inserted into versions: {e}"
+                        .format(item_id=item_id, e=e))
 
             # archive_service.update(item_id, updates, item)
             logger.info("item {item_id} reached compliance end-of-life, it has been corrected".format(item_id=item_id))

--- a/server/fidelity/tests/compliance_test.py
+++ b/server/fidelity/tests/compliance_test.py
@@ -38,3 +38,6 @@ class ComplianceCorrectionTestCase(TestCase):
         self.assertTrue(item['body_text'].startswith(DEFAULT_EOL_TEXT))
         self.assertTrue(item['body_html'].startswith(
             '<p class="compliance-notice">{DEFAULT_EOL_TEXT}</p>'.format(DEFAULT_EOL_TEXT=DEFAULT_EOL_TEXT)))
+        archive_versions_service = get_resource_service('archive_versions')
+        version_item = archive_versions_service.find_one(None, guid='123', _current_version=2)
+        self.assertIsNotNone(version_item)


### PR DESCRIPTION
new version of corrected item was not added in archive_versions: this is done
by eve, so it is skipped when correction is done internally from the
backend. This patch fixes it by calling the method manually.

This fixes package item preview in client: by requesting a specific
version (the one not inserted), the client was getting a 404, resulting
in the described bug.

fixes SDFID-598