### PR TITLE
[QUMU] implement QUMU embed modification:

### DIFF
--- a/server/fidelity/qumu.py
+++ b/server/fidelity/qumu.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import re
+import json
+import uuid
+import logging
+from functools import partial
+
+logger = logging.getLogger(__name__)
+QUMU_RE = re.compile(r'KV\.widget\(({.*})\)')
+
+
+def qumu_config_modifier(match, selector):
+    conf_json = json.loads(match.group(1))
+    conf_json['selector'] = selector
+    return "KV.widget({})".format(json.dumps(conf_json))
+
+
+def qumu_embed_pre_process(data):
+    """dump QUMU config json as string + add selector"""
+    try:
+        html = data['html']
+    except KeyError:
+        logging.error('missing "html" key in data: {data}'.format(
+            data=data))
+        return
+
+    if not QUMU_RE.search(html):
+        # this is not a QUMU embed
+        return
+
+    try:
+        selector = "qumu-{}".format(uuid.uuid4())
+        final_div = '<div id="{selector}"></div>'.format(selector=selector)
+        data['html'] = QUMU_RE.sub(
+            partial(qumu_config_modifier, selector=selector),
+            html,
+            count=1
+        ) + final_div
+    except Exception as e:
+        logger.warning("Invalid QUMU embed: {e}\n{data}".format(e=e, data=data))

--- a/server/fidelity/tests/qumu_test.py
+++ b/server/fidelity/tests/qumu_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# This file is part of Superdesk.
+#
+# Copyright 2018 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+"""Unit tests for Qumu module"""
+
+import sys
+import re
+from unittest import skipIf
+from superdesk.tests import TestCase
+from superdesk.editor_utils import Editor3Content
+from fidelity.qumu import qumu_embed_pre_process
+
+
+class QumuTestCase(TestCase):
+
+    def build_item(self, draftjs_data, field='body_html'):
+        return {
+            'fields_meta': {
+                field: {
+                    'draftjsState': [draftjs_data],
+                },
+            },
+        }
+
+    @skipIf(
+        sys.version_info[:2] <= (3, 5),
+        "Python 3.5 doesn't keep dict key insertion order, making this test fail"
+    )
+    def test_qumu_embed_pre_process(self):
+        """Check that Qumu embed is pre-processed, with json dump and selector added
+
+        cf. SDESK-4939 and SDFID-5
+        """
+        self.app.config['EMBED_PRE_PROCESS'] = [qumu_embed_pre_process]
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "d60k5",
+                    "text": " ",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+                {
+                    "key": "dusi6",
+                    "text": " ",
+                    "type": "atomic",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [{"offset": 0, "length": 1, "key": 0}],
+                    "data": {},
+                },
+                {
+                    "key": "dr7r5",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {
+                "0": {
+                    "type": "EMBED",
+                    "mutability": "MUTABLE",
+                    "data": {
+                        "data": {
+                            "html": '<script type="text/javascript" src="https://video.fidelity.tv/widgets/application'
+                                    '.js"></script> <script type="text/javascript"> KV.widget({   "guid": "LS80jXTAMH9'
+                                    '",   "type": "thumbnail",   "playerType": "full",   "size": 10 }); </script>'
+                        }
+                    },
+                }
+            },
+        }
+        item = self.build_item(draftjs_data)
+        body_editor = Editor3Content(item)
+        body_editor.update_item()
+        expected = (
+            '<div class="embed-block"><script type="text/javascript" src="https://video.fidelity.tv/widgets/application'
+            '.js"></script><script type="text/javascript"> KV.widget({"guid": "LS80jXTAMH9", "type": "thumbnail", "play'
+            'erType": "full", "size": 10, "selector": "qumu-UUID_RE"}); </script><div id="qumu-UUID_RE"></div></div>'
+        )
+
+        # we have to use a regex because the UUID of the selector is not predictable
+        expected_re = re.escape(expected).replace("UUID_RE", '[-0-9a-f]+')
+        self.assertIsNotNone(re.match(expected_re, item['body_html']))

--- a/server/settings.py
+++ b/server/settings.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from superdesk.default_settings import CELERY_BEAT_SCHEDULE, INSTALLED_APPS
 from celery.schedules import crontab
 from content_api.app.settings import CONTENTAPI_INSTALLED_APPS
+from fidelity.qumu import qumu_embed_pre_process
 
 
 def env(variable, fallback_value=None):
@@ -135,3 +136,7 @@ INTERNAL_ID_SET_CUSTOM_FIELD_ID = "internal_id"
 # internal id will be appended to following fields (after a line feed),
 # if they exist in content profile
 INTERNAL_ID_APPEND_CUSTOM_FIELDS_IDS = ['disclaimer']
+
+# HTML rendering
+
+EMBED_PRE_PROCESS = [qumu_embed_pre_process]


### PR DESCRIPTION
QUMU embed was modified in client when HTML was generated (see SDFID-5).
This patch does the same in the backend as the HTML export from DraftJS
can now be done in backend too.