### PR TITLE
[MACROS] [SET_GERMAN_AND_PUBLISH] fixed extra duplications

### DIFF
--- a/server/fidelity/macros/set_german_and_publish.py
+++ b/server/fidelity/macros/set_german_and_publish.py
@@ -34,7 +34,7 @@ def set_german_and_publish(item, **kwargs):
             'language': 'de',
         }
 
-        new_id = archive_service.duplicate_content(item, state='routed')
+        new_id = archive_service.duplicate_item(item, state='routed')
         updates[ITEM_STATE] = item.get(ITEM_STATE)
         updates[PROCESSED_FROM] = item[config.ID_FIELD]
 


### PR DESCRIPTION
For the same reason as for
https://github.com/superdesk/superdesk-core/commit/6964b7fb08e78379224026239107b186607b41bc,
package items where duplicated twice.
This patch fixes it by using `duplicate_item` instead of
`duplicate_content`.

This patch also switch superdesk-core from `requirements.txt` to `>=1.33.3,<1.34`
branch to make CI happy.

fixes SDFID-602