### PR TITLE
[INSTALL] update lxml version to 4.1.1

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,6 +2,6 @@ gunicorn==19.7.1
 honcho==1.0.1
 newrelic>=2.66,<2.67
 python3-saml==1.2.6
-lxml==3.8.0
+lxml==4.1.1
 feedgen==0.9.0
 superdesk-core>=1.33.3,<1.34


### PR DESCRIPTION
`lxml 3.8.0` is really old and cause troubles, `4.1.1` is the highest
version which is still compatible with `superdesk-core` current
requirements (<4.2).