### PR TITLE
fix client core version used

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,6 @@
     "license": "GPL-3.0",
     "dependencies": {
         "angular-sanitize": "^1.6.7",
-        "superdesk-core": "superdesk/superdesk-client-core#develop"
+        "superdesk-core": "superdesk/superdesk-client-core#release/1.34"
     }
 }

--- a/server/manage.py
+++ b/server/manage.py
@@ -12,7 +12,7 @@
 """Superdesk Manager"""
 
 import superdesk
-from flask.ext.script import Manager
+from flask_script import Manager
 from app import get_app
 
 app = get_app()


### PR DESCRIPTION
`develop` client branch is not working with backend version used here
(<1.34). This patch fixes it by using `release/1.34` branch.

Also fixed legacy import in `manage.py`

SDESK-5924