### PR TITLE
[CONTENT API][RSS] update permalink following new requirements

### DIFF
--- a/server/fidelity/content_api_rss.py
+++ b/server/fidelity/content_api_rss.py
@@ -21,22 +21,38 @@ BASE_URL = "https://www.fidelityinternational.com/"
 
 
 def get_permalink(item):
+    try:
+        content_type = next(
+            g["qcode"][13:].lower().strip() for g in item.get("genre", [])
+            if g.get("qcode", "").startswith("genre_custom:")
+        )
+    except StopIteration:
+        content_type = ""
+
+    try:
+        title = item["extra"][PERMALINK]
+    except KeyError:
+        title = None
+
+    if not title:
+        title = item.get("headline") or item["name"]
+
     return urljoin(
         BASE_URL,
-        "/editorial/{profile}/{title}-{guid_end}-en5/".format(
-            profile=item['profile'],
-            title=slugify(item.get('headline') or item['name']),
-            guid_end=(item.get('guid') or item['_id'])[-6:],
+        "/editorial/{content_type}/{title}-{guid_end}-en5/".format(
+            content_type=content_type,
+            title=slugify(title),
+            guid_end=(item.get("guid") or item["_id"])[-6:],
         ),
     )
 
 
 def get_content(item):
     try:
-        return item['extra']['Summary'] or ''
+        return item["extra"]["Summary"] or ""
     except (KeyError, TypeError):
         pass
-    return item.get('description_html') or ''
+    return item.get("description_html") or ""
 
 
 def generate_feed(items):

--- a/server/fidelity/tests/rss_test.py
+++ b/server/fidelity/tests/rss_test.py
@@ -6,12 +6,29 @@ def test_get_permalink():
         get_permalink(
             {
                 "_id": "guid:foo-bar-baz-5b4111",
-                "headline": "I can't avoid risk. How do I take it wisely?",
+                "headline": "I can't avoid risk.",
                 "profile": "123",
                 "extra": {PERMALINK: "I can't avoid risk. How do I take it wisely?"},
+                "genre": [
+                    {
+                        "name": "Article",
+                        "qcode": "genre_custom:Article",
+                        "translations": {
+                            "name": {
+                                "it": "Articolo",
+                                "ja": "レポート",
+                                "de": "Artikel"
+                            }
+                        },
+                        "scheme": "genre_custom"
+                    }
+                ],
             }
         )
-        == "https://www.fidelityinternational.com/editorial/123/i-cant-avoid-risk-how-do-i-take-it-wisely-5b4111-en5/"
+        == (
+            "https://www.fidelityinternational.com/editorial/article/"
+            "i-cant-avoid-risk-how-do-i-take-it-wisely-5b4111-en5/"
+        )
     )
 
     assert (
@@ -22,7 +39,33 @@ def test_get_permalink():
                 "name": "some name",
                 "language": "ja",
                 "extra": {PERMALINK: None},
+                "genre": [
+                    {
+                        "name": "Article",
+                        "qcode": "genre_custom:Article",
+                        "translations": {
+                            "name": {
+                                "it": "Articolo",
+                                "ja": "レポート",
+                                "de": "Artikel"
+                            }
+                        },
+                        "scheme": "genre_custom"
+                    },
+                    {
+                        "name": "Blog",
+                        "qcode": "genre_custom:Blog",
+                        "translations": {
+                            "name": {
+                                "it": "Blog",
+                                "ja": "ブログ",
+                                "de": "Blog"
+                            }
+                        },
+                        "scheme": "genre_custom"
+                    }
+                ],
             }
         )
-        == "https://www.fidelityinternational.com/editorial/123/some-name-61c89a-en5/"
+        == "https://www.fidelityinternational.com/editorial/article/some-name-61c89a-en5/"
     )


### PR DESCRIPTION
- use content type instead of content profile id. When several content
  types are set, the first one is used, if none is available, empty
  string is used.
- use permalink field when available

SDFID-610